### PR TITLE
added 'fallbackPort' configuration option

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,6 +29,9 @@ var DEFAULT_ERROR_MESSAGE   = 'Server error.';
  *   }
  *   subdomains (optional): An object mapping subdomains to ports. Use ''
  *                          to indicate the home page port.
+ *   fallbackPort (optional): If specified, requests targeting a subdomain
+ *                            not present in the domain mapping will be
+ *                            routed to the fallback port.
  */
 module.exports = function generateServer(config) {
 
@@ -46,13 +49,18 @@ module.exports = function generateServer(config) {
 
     // Handle edge cases
     if (!targetPort) { // If there is no target port
-      if (subdomain === '') { // ...and the user requested the home page
-        util.sendResponse(res, 200, config.messages.home);
-      } else { // ...and the user requested an invalid subdomain
-        util.sendResponse(res, 400, config.messages.invalid);
+      if(config.fallbackPort) {
+        targetPort = config.fallbackPort;
       }
+      else {
+        if (subdomain === '') { // ...and the user requested the home page
+          util.sendResponse(res, 200, config.messages.home);
+        } else { // ...and the user requested an invalid subdomain
+          util.sendResponse(res, 400, config.messages.invalid);
+        }
 
-      return;
+        return;
+      }
     }
 
     // Craft the request to the actual service
@@ -77,11 +85,6 @@ module.exports = function generateServer(config) {
     proxyRequest.on('response', function(proxyResponse) {
       res.writeHead(proxyResponse.statusCode, proxyResponse.headers);
       proxyResponse.pipe(res);
-    });
-    
-    // propagate request cancellation
-    res.on('close', function() {
-      proxyRequest.abort();
     });
 
     // Open the floodgates!


### PR DESCRIPTION
If a fallback port is specified, requests targeting a subdomain not present in the domain mapping will be routed to that port.
